### PR TITLE
Circumvent netease source geolocation restriction

### DIFF
--- a/src/sources/netease.cpp
+++ b/src/sources/netease.cpp
@@ -31,6 +31,7 @@ static http_request::ptr make_post_request()
     request->add_header("Cookie", "appver=2.0.2");
     request->add_header("charset", "utf-8");
     request->add_header("Content-Type", "application/x-www-form-urlencoded");
+    request->add_header("X-Real-IP", "202.106.0.0");
     return request;
 }
 


### PR DESCRIPTION
The NetEase API cannot be used outside of China - normal search API searches for strange things and the web API variant is encrypted. Adding a header could trick NetEase's server to think we are in China.

In theory we can use the web API instead and decrypt the response if we are abroad, but we certainly don't want to check in the decryption key here, and normal users obviously don't know how to acquire that.
