### PR TITLE
added lyrics navigation feature

### DIFF
--- a/src/ui_lyrics_panel.cpp
+++ b/src/ui_lyrics_panel.cpp
@@ -24,6 +24,7 @@
 #include "ui_lyrics_panel.h"
 #include "ui_util.h"
 #include "win32_util.h"
+static std::vector<LyricPanel*> g_active_panels;
 
 namespace {
     // NOTE: This needs to be stored per-instance so that they all have their own
@@ -31,7 +32,12 @@ namespace {
     //       (e.g by having several panels all try to stop the same timer).
     static UINT_PTR PANEL_UPDATE_TIMER = 2304692;
 
-    static std::vector<LyricPanel*> g_active_panels;
+    //static std::vector<LyricPanel*> g_active_panels;
+}
+
+std::vector<LyricPanel*>& get_active_panels()
+{
+    return g_active_panels;
 }
 
 LyricPanel::LyricPanel() :

--- a/src/ui_lyrics_panel.h
+++ b/src/ui_lyrics_panel.h
@@ -5,6 +5,9 @@
 #include "img_processing.h"
 #include "lyric_io.h"
 #include "metadb_index_search_avoidance.h"
+#include <vector> 
+class LyricPanel;
+std::vector<LyricPanel*>& get_active_panels(); 
 
 class LyricPanel : public CWindowImpl<LyricPanel>, protected ui_config_callback_impl, private play_callback
 {
@@ -24,6 +27,7 @@ public:
     void on_playback_dynamic_info_track(const file_info& info) override;
     void on_playback_time(double /*time*/) override {}
     void on_volume_change(float /*new_volume*/) override {}
+    const LyricData& get_lyrics() const { return m_lyrics; } // m_lyrics getter
 
     CRect compute_background_image_rect();
     void load_custom_background_image();


### PR DESCRIPTION
Implemented feature - lyrics navigation. Added 3 context menu buttons:
1. Seek to next lyric timestamp
2. Seek to prev lyric timestamp
3. Seek to `repeat current lyric timestamp`

<img src="https://github.com/user-attachments/assets/416dd99f-cd1e-4a08-ba6c-8ffbe48a0cc1" width="700" />

<br /><br />

Context menu buttons can be assigned keyboard hotkeys   <br />
<img src="https://github.com/user-attachments/assets/cac6edfe-3bda-4c06-bf0f-87a216eb4426" width="600" />



And then use it like this

https://github.com/user-attachments/assets/1cfde9c1-cff1-4fb5-9dec-57f0df3fc55c


Good for studying foreign languages.