### PR TITLE
Fix #472 by checking for instrumental markings during bulk search

### DIFF
--- a/src/ui_contextmenu.cpp
+++ b/src/ui_contextmenu.cpp
@@ -287,7 +287,7 @@ public:
                         }
                         search_avoidance_force_by_mark_instrumental(track, track_info);
                     }
-                    LOG_INFO("Finished marking %d tracks as instrumental with %d failures", int(failure_count));
+                    LOG_INFO("Finished marking %d tracks as instrumental with %d failures", int(track_count), int(failure_count));
 
                     fb2k::inMainThread2(
                         [failure_count, track_count]()


### PR DESCRIPTION
This code adds the instrumental checking seen in lyric_search.cpp to ui_lyric_bulk_search.cpp, as the previous code only checked for instrumentals during autoplay. This code also fixes a minor logging bug. Lyrics can still be checked for instrumental songs by running `Search for lyrics (manually)`.