### PR TITLE
feat: Add 'Average image colour' background fill mode

### DIFF
--- a/src/config/ui_preferences_display_background.cpp
+++ b/src/config/ui_preferences_display_background.cpp
@@ -40,6 +40,7 @@ static const cfg_auto_combo_option<BackgroundFillType> g_background_fill_options
     { _T("Default"), BackgroundFillType::Default },
     { _T("Solid colour"), BackgroundFillType::SolidColour },
     { _T("Gradient"), BackgroundFillType::Gradient },
+    { _T("Average image colour"), BackgroundFillType::AverageImageColor },
 };
 
 static const cfg_auto_combo_option<BackgroundImageType> g_background_image_options[] = {
@@ -48,7 +49,7 @@ static const cfg_auto_combo_option<BackgroundImageType> g_background_image_optio
     { _T("Custom image"), BackgroundImageType::CustomImage },
 };
 
-static cfg_auto_combo<BackgroundFillType, 3> cfg_background_fill_type(GUID_CFG_BACKGROUND_MODE,
+static cfg_auto_combo<BackgroundFillType, 4> cfg_background_fill_type(GUID_CFG_BACKGROUND_MODE,
                                                                       IDC_BACKGROUND_FILL_TYPE,
                                                                       BackgroundFillType::Default,
                                                                       g_background_fill_options);

--- a/src/img_processing.cpp
+++ b/src/img_processing.cpp
@@ -370,6 +370,41 @@ void transpose_image_noalloc(int width, int height, const uint8_t* in_pixels, ui
             }
         }
     }
+
+RGBAColour compute_average_colour(const Image& img)
+{
+    if(!img.valid())
+    {
+        return {};
+    }
+
+    uint64_t total_r = 0;
+    uint64_t total_g = 0;
+    uint64_t total_b = 0;
+
+    for(int y=0; y<img.height; y++)
+    {
+        for(int x=0; x<img.width; x++)
+        {
+            uint8_t* px = img.pixels + (y * img.width + x) * 4;
+            total_r += px[0];
+            total_g += px[1];
+            total_b += px[2];
+        }
+    }
+
+    const uint64_t num_pixels = img.width * img.height;
+    if(num_pixels == 0)
+    {
+        return {};
+    }
+
+    uint8_t avg_r = (uint8_t)(total_r / num_pixels);
+    uint8_t avg_g = (uint8_t)(total_g / num_pixels);
+    uint8_t avg_b = (uint8_t)(total_b / num_pixels);
+
+    return {avg_r, avg_g, avg_b, 255};
+}
 }
 Image transpose_image(const Image& img)
 {
@@ -526,6 +561,37 @@ static void boxblur_horizontal_noalloc(int width, int height, const uint8_t* in_
         }
     }
 }
+
+RGBAColour compute_average_colour(const Image& img)
+{
+    if(!img.valid())
+    {
+        return {};
+    }
+
+    uint64_t total_r = 0;
+    uint64_t total_g = 0;
+    uint64_t total_b = 0;
+
+    for(int y=0; y<img.height; y++)
+    {
+        for(int x=0; x<img.width; x++)
+        {
+            uint8_t* px = img.pixels + (y * img.width + x) * 4;
+            total_r += px[0];
+            total_g += px[1];
+            total_b += px[2];
+        }
+    }
+
+    const uint64_t num_pixels = img.width * img.height;
+    uint8_t avg_r = (uint8_t)(total_r / num_pixels);
+    uint8_t avg_g = (uint8_t)(total_g / num_pixels);
+    uint8_t avg_b = (uint8_t)(total_b / num_pixels);
+
+    return {avg_r, avg_g, avg_b, 255};
+}
+
 static Image image_boxblur_linear_horizontal(const Image& img, int radius)
 {
     uint8_t* pixels = (uint8_t*)malloc(img.width * img.height * 4);

--- a/src/img_processing.h
+++ b/src/img_processing.h
@@ -43,6 +43,7 @@ Image lerp_image(const Image& lhs, const Image& rhs, double t);
 Image lerp_offset_image(const Image& full_img, const Image& offset_img, CPoint offset, double t);
 Image resize_image(const Image& input, int out_width, int out_height);
 Image transpose_image(const Image& input);
+RGBAColour compute_average_colour(const Image& img);
 Image blur_image(const Image& input, int radius);
 
 void toggle_image_rgba_bgra_inplace(Image& img);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -57,6 +57,7 @@ enum class BackgroundFillType : int
     Default = 0,
     SolidColour = 1,
     Gradient = 2,
+    AverageImageColor = 3,
 };
 
 enum class BackgroundImageType : int

--- a/src/ui_lyrics_panel.cpp
+++ b/src/ui_lyrics_panel.cpp
@@ -143,6 +143,7 @@ void LyricPanel::compute_background_image()
     }
 
     Image bg_colour = {};
+    const BackgroundImageType img_type = preferences::background::image_type();
     switch(preferences::background::fill_type())
     {
         case BackgroundFillType::Default:
@@ -174,9 +175,23 @@ void LyricPanel::compute_background_image()
                                                    botright);
         }
         break;
+
+        case BackgroundFillType::AverageImageColor:
+        {
+            RGBAColour colour = from_colorref(defaultui::background_colour());
+            if(img_type == BackgroundImageType::AlbumArt)
+            {
+                colour = compute_average_colour(m_albumart_original);
+            }
+            else if(img_type == BackgroundImageType::CustomImage)
+            {
+                colour = compute_average_colour(m_custom_img_original);
+            }
+            bg_colour = generate_background_colour(client_rect.Width(), client_rect.Height(), colour);
+        }
+        break;
     }
 
-    const BackgroundImageType img_type = preferences::background::image_type();
     if(img_type == BackgroundImageType::None)
     {
         m_background_img = std::move(bg_colour);


### PR DESCRIPTION
LLM generated

background fill mode that fills the background of the lyrics panel with the average colour of the background image.

A new option, 'Average image colour', has been added to the background fill mode dropdown in the preferences. When this option is selected, the average colour of the album art or custom background image is calculated and used as the background colour for the panel. This provides a more visually appealing background when the image does not fill the entire panel.

The following changes were made:
- Added `AverageImageColor` to the `BackgroundFillType` enum in `src/preferences.h`.
- Updated the preferences UI in `src/config/ui_preferences_display_background.cpp` to include the new option.
- Implemented the `compute_average_colour` function in `src/img_processing.cpp` to calculate the average colour of an image.
- Modified `LyricPanel::compute_background_image` in `src/ui_lyrics_panel.cpp` to use the new fill mode.

