### PR TITLE
Check file existence before searching for lyrics

### DIFF
--- a/src/lyric_search.cpp
+++ b/src/lyric_search.cpp
@@ -190,15 +190,17 @@ void LyricAutosearchManager::on_playback_new_track(metadb_handle_ptr track)
 
     const bool search_postponed_for_dynamic_info = track_is_remote(
         track); // If this is an internet radio then don't search until we get dynamic track info
-    const bool file_exists = track_file_exists(track);
-    const bool should_search = track_changed && !search_postponed_for_dynamic_info && file_exists;
+    const bool search_skipped_for_missing_local_file = !search_postponed_for_dynamic_info && !track_exists_on_filesystem(
+        track); // Skip search for missing local files as it can create lyric files and directories for missing paths
+    const bool should_search = track_changed && !search_postponed_for_dynamic_info && !search_skipped_for_missing_local_file;
     if(!should_search)
     {
         LOG_INFO("Skipping new-playback search. %s, %s, %s",
                  track_changed ? "The track has changed" : "The track didn't change",
                  search_postponed_for_dynamic_info ? "the search is being postponed waiting for dynamic info"
                                                    : "we're not waiting for dynamic track info",
-                 file_exists ? "the track file exists" : "the track file does not exist");
+                 search_skipped_for_missing_local_file ? "the search is being skipped due to a missing local file"
+                                                       : "the search is not being skipped due to a missing local file");
         return;
     }
 

--- a/src/lyric_search.cpp
+++ b/src/lyric_search.cpp
@@ -190,13 +190,15 @@ void LyricAutosearchManager::on_playback_new_track(metadb_handle_ptr track)
 
     const bool search_postponed_for_dynamic_info = track_is_remote(
         track); // If this is an internet radio then don't search until we get dynamic track info
-    const bool should_search = track_changed && !search_postponed_for_dynamic_info;
+    const bool file_exists = track_file_exists(track);
+    const bool should_search = track_changed && !search_postponed_for_dynamic_info && file_exists;
     if(!should_search)
     {
-        LOG_INFO("Skipping new-playback search. %s, %s",
+        LOG_INFO("Skipping new-playback search. %s, %s, %s",
                  track_changed ? "The track has changed" : "The track didn't change",
                  search_postponed_for_dynamic_info ? "the search is being postponed waiting for dynamic info"
-                                                   : "we're not waiting for dynamic track info");
+                                                   : "we're not waiting for dynamic track info",
+                 file_exists ? "the track file exists" : "the track file does not exist");
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,9 @@ namespace
         out += "\nChangelog:\n";
         // out += "Version " OPENLYRICS_VERSION " (" __DATE__ "):\n"
         // "\n";
+        out += "Version " OPENLYRICS_VERSION " (" __DATE__ "):\n"
+               "- Fix auto-search triggering for missing local files\n"
+               "\n";
         out += "Version 1.13 (2026-01-17):\n"
                "- Enable searching local sources with no visible panels by default\n"
                "- Add some clarifying help to the 'Exclude trailing brackets' search option\n"

--- a/src/tag_util.cpp
+++ b/src/tag_util.cpp
@@ -254,13 +254,8 @@ bool track_is_remote(metadb_handle_ptr track)
 #endif
 }
 
-bool track_file_exists(metadb_handle_ptr track)
+bool track_exists_on_filesystem(metadb_handle_ptr track)
 {
-    if(track_is_remote(track))
-    {
-        return true; // Remote tracks don't have local files to check
-    }
-
     try
     {
         const char* path = track->get_path();

--- a/src/tag_util.cpp
+++ b/src/tag_util.cpp
@@ -254,6 +254,24 @@ bool track_is_remote(metadb_handle_ptr track)
 #endif
 }
 
+bool track_file_exists(metadb_handle_ptr track)
+{
+    if(track_is_remote(track))
+    {
+        return true; // Remote tracks don't have local files to check
+    }
+
+    try
+    {
+        const char* path = track->get_path();
+        return filesystem::g_exists(path, fb2k::noAbort);
+    }
+    catch(const std::exception&)
+    {
+        return false;
+    }
+}
+
 bool starts_with_ignore_case(std::string_view input, std::string_view prefix)
 {
     if(input.length() < prefix.length())

--- a/src/tag_util.h
+++ b/src/tag_util.h
@@ -20,3 +20,4 @@ bool tag_values_match(std::string_view tagA, std::string_view tagB);
 std::optional<int> track_duration_in_seconds(const metadb_v2_rec_t& track);
 
 bool track_is_remote(metadb_handle_ptr track);
+bool track_file_exists(metadb_handle_ptr track);

--- a/src/tag_util.h
+++ b/src/tag_util.h
@@ -20,4 +20,4 @@ bool tag_values_match(std::string_view tagA, std::string_view tagB);
 std::optional<int> track_duration_in_seconds(const metadb_v2_rec_t& track);
 
 bool track_is_remote(metadb_handle_ptr track);
-bool track_file_exists(metadb_handle_ptr track);
+bool track_exists_on_filesystem(metadb_handle_ptr track);


### PR DESCRIPTION
When a playlist has tracks that no longer exist on disk, foobar2000 skips past them instantly to the next track. The plugin still tries to search lyrics for each one though, so it ends up rapidly downloading lyrics for all of them and creating the full directory structure for each of the missing file paths in the playlist. You can end up with massive folder trees containing nothing but lyric files.

This adds a check so that lyrics search is skipped if file doesn't exist. Compiled and tested on my end, works as expected.